### PR TITLE
Prepare for portable Node UI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ variables:
 
 build:
   stage: deploy
-  image: golang:1.13
+  image: golang:1.17.5
   tags: [go]
   script:
     - git fetch origin --prune +refs/heads/*:refs/heads/*

--- a/README.md
+++ b/README.md
@@ -10,32 +10,26 @@ To re-generate the `assets_vfsdata.go`, either `mage generate` or `go run mage.g
 
 To bundle webUI locally:
 
-1)  Export path to WebUI root source directory:
+1)  Export version you would like to bundle (makes sure it is available in [dpv-web releases](https://github.com/mysteriumnetwork/dvpn-web/releases))
     
     ```console
-    $ export DVPN_WEB_LOCAL_PATH=/Users/user/dev/src/dvpn-web
+    $ export GIT_TAG_VERSION=1.2.1
     ```
 
-2) Generate local dist.tar.gz by running yarn command in .../dvpn-web
+2) Bundle dist
 
     ```console
-    $ yarn local_release
-    ```
-   
-3) Bundle dist
-
-    ```console
-   $ mage GenerateLocal
+   $ mage Generate
    ```
    or
    ```console
-   $ go run mage.go GenerateLocal
+   $ go run mage.go Generate
    ```
    
-4) In node source root replace module
+3) In node source root replace module
 
     ```console
    $ go mod edit -replace github.com/mysteriumnetwork/go-dvpn-web=/Users/user/go/src/go-dvpn-web 
    ```
    
-5) Finally, build and run node!
+4) Finally, build and run node!

--- a/ci/ci.go
+++ b/ci/ci.go
@@ -50,7 +50,7 @@ func CI() error {
 
 	defer Cleanup()
 	mg.SerialDeps(
-		DownloadLatestAssets,
+		DownloadAssets,
 		ExtractAssets,
 		FixDirectory,
 		GoGenerate,

--- a/ci/generate.go
+++ b/ci/generate.go
@@ -82,12 +82,17 @@ func Generate() error {
 
 // DownloadLatestAssets fetches the latest assets from github
 func DownloadLatestAssets() error {
-	fmt.Println("getting latest release")
+	tagVersion := os.Getenv("GIT_TAG_VERSION")
+	if tagVersion == "" {
+		return errors.New("please specify the GIT_TAG_VERSION environment variable")
+	}
+
+	fmt.Println(fmt.Sprintf("getting dvpn-web release: %s", tagVersion))
 
 	client := &http.Client{
 		Timeout: time.Minute,
 	}
-	req, err := http.NewRequest("GET", "https://api.github.com/repos/mysteriumnetwork/dvpn-web/releases/latest", nil)
+	req, err := http.NewRequest("GET", "https://api.github.com/repos/mysteriumnetwork/dvpn-web/releases/tags/"+tagVersion, nil)
 	if err != nil {
 		return err
 	}

--- a/ci/generate.go
+++ b/ci/generate.go
@@ -32,47 +32,16 @@ import (
 	"github.com/mholt/archiver/v3"
 )
 
-const localDvpnWebPath = "DVPN_WEB_LOCAL_PATH"
-const assetName = "dist.tar.gz"
+const distAssetName = "dist.tar.gz"
+const compatibilityAssetName = "compatibility.json"
 const tempDir = "temp"
 const assetDir = "assets"
-
-// GenerateLocal hello world
-func GenerateLocal() error {
-	if os.Getenv(localDvpnWebPath) == "" {
-		return errors.New("please set " + localDvpnWebPath + " environment variable")
-	}
-
-	defer Cleanup()
-	mg.SerialDeps(
-		CopyLocalAssets,
-		ExtractAssets,
-		FixDirectory,
-		GoGenerate,
-	)
-	return nil
-}
-
-func CopyLocalAssets() error {
-	pathToDist := os.Getenv(localDvpnWebPath) + "/" + assetName
-	fmt.Println("Copying assets from: " + pathToDist)
-	out, err := os.Create(assetName)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	open, _ := os.Open(pathToDist)
-	_, err = io.Copy(out, open)
-	defer open.Close()
-	return err
-}
 
 // Generate re-generates the assets_vfsdata.go
 func Generate() error {
 	defer Cleanup()
 	mg.SerialDeps(
-		DownloadLatestAssets,
+		DownloadAssets,
 		ExtractAssets,
 		FixDirectory,
 		GoGenerate,
@@ -80,8 +49,8 @@ func Generate() error {
 	return nil
 }
 
-// DownloadLatestAssets fetches the latest assets from github
-func DownloadLatestAssets() error {
+// DownloadAssets fetches the latest assets from github
+func DownloadAssets() error {
 	tagVersion := os.Getenv("GIT_TAG_VERSION")
 	if tagVersion == "" {
 		return errors.New("please specify the GIT_TAG_VERSION environment variable")
@@ -124,6 +93,17 @@ func DownloadLatestAssets() error {
 		return errors.New("no assets in latest release")
 	}
 
+	if err := findAndDownloadAsset(rr, distAssetName, true); err != nil {
+		return err
+	}
+	if err := findAndDownloadAsset(rr, compatibilityAssetName, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func findAndDownloadAsset(rr ReleasesResponse, assetName string, required bool) error {
 	found := -1
 	for i, v := range rr.Assets {
 		if v.Name == assetName {
@@ -131,13 +111,17 @@ func DownloadLatestAssets() error {
 		}
 	}
 
+	if found < 0 && !required {
+		fmt.Println(fmt.Sprintf("asset: %s - not found, but is not required - skipping", assetDir))
+		return nil
+	}
+
 	if found < 0 {
 		return fmt.Errorf("no %q found in assets of release", assetName)
 	}
 
 	fmt.Println("downloading file", rr.Assets[found].BrowserDownloadURL)
-	err = downloadFile(assetName, rr.Assets[found].BrowserDownloadURL)
-	if err != nil {
+	if err := downloadFile(assetName, rr.Assets[found].BrowserDownloadURL); err != nil {
 		return err
 	}
 
@@ -153,12 +137,12 @@ func ExtractAssets() error {
 			MkdirAll:          true,
 		},
 	}
-	fmt.Println("extracting archive", assetName)
-	err := z.Unarchive(assetName, tempDir)
+	fmt.Println("extracting archive", distAssetName)
+	err := z.Unarchive(distAssetName, tempDir)
 	if err != nil {
 		return err
 	}
-	fmt.Println("archive", assetName, "extracted")
+	fmt.Println("archive", distAssetName, "extracted")
 	return nil
 }
 
@@ -177,7 +161,7 @@ func FixDirectory() error {
 func Cleanup() error {
 	fmt.Println("cleaning up...")
 	toClean := []string{
-		tempDir, assetDir, assetName,
+		tempDir, assetDir, distAssetName,
 	}
 
 	for _, v := range toClean {

--- a/compatibility.go
+++ b/compatibility.go
@@ -1,0 +1,18 @@
+package dvpnweb
+
+import (
+	_ "embed"
+	"encoding/json"
+)
+
+//go:embed compatibility.json
+var compatibilityJson []byte
+
+func MinimalCompatibleNodeVersion() (string, error) {
+	var c Compatibility
+	return c.MinimalNodeVersion, json.Unmarshal(compatibilityJson, &c)
+}
+
+type Compatibility struct {
+	MinimalNodeVersion string `json:"minimalNodeVersion"`
+}

--- a/compatibility.json
+++ b/compatibility.json
@@ -1,0 +1,3 @@
+{
+  "minimalNodeVersion": "1.0.18"
+}

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,38 @@
 module github.com/mysteriumnetwork/go-dvpn-web
 
-go 1.13
+go 1.17
 
 require (
 	github.com/magefile/mage v1.9.0
 	github.com/mholt/archiver/v3 v3.3.0
 	github.com/mysteriumnetwork/go-ci v0.0.0-20200415074834-39fc864b0ed4
-	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
 	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd
+)
+
+require (
+	github.com/andybalholm/brotli v0.0.0-20190621154722-5f990b63d2d6 // indirect
+	github.com/dsnet/compress v0.0.1 // indirect
+	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/golang/gddo v0.0.0-20190419222130-af0f2af80721 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/kevinburke/ssh_config v0.0.0-20180830205328-81db2a75821e // indirect
+	github.com/klauspost/compress v1.9.2 // indirect
+	github.com/klauspost/pgzip v1.2.1 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/nwaples/rardecode v1.0.0 // indirect
+	github.com/pelletier/go-buffruneio v0.2.0 // indirect
+	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
+	github.com/sergi/go-diff v1.0.0 // indirect
+	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
+	github.com/src-d/gcfg v1.4.0 // indirect
+	github.com/ulikunitz/xz v0.5.6 // indirect
+	github.com/xanzy/ssh-agent v0.2.1 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
+	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
+	golang.org/x/net v0.0.0-20190628185345-da137c7871d7 // indirect
+	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
+	gopkg.in/src-d/go-billy.v4 v4.3.1 // indirect
 	gopkg.in/src-d/go-git.v4 v4.12.0 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,7 +16,6 @@ github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdf
 github.com/emirpasic/gods v1.9.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
-github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/gliderlabs/ssh v0.1.3 h1:cBU46h1lYQk5f2Z+jZbewFKy+1zzE2aUX/ilcPDAm9M=
@@ -48,7 +47,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/magefile/mage v1.8.0 h1:mzL+xIopvPURVBwHG9A50JcjBO+xV3b5iZ7khFRI+5E=
 github.com/magefile/mage v1.8.0/go.mod h1:IUDi13rsHje59lecXokTfGX0QIzO45uVPlXnJYsXepA=
 github.com/magefile/mage v1.9.0 h1:t3AU2wNwehMCW97vuqQLtw6puppWXHO+O2MHo5a50XE=
 github.com/magefile/mage v1.9.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
@@ -119,7 +117,6 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb h1:fgwFCsaw9buMuxNd6+DQfAuSFqbNiQZpcgJQAgJsK6k=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -134,7 +131,6 @@ google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/src-d/go-billy.v4 v4.2.1/go.mod h1:tm33zBoOwxjYHZIE+OV8bxTWFMJLrconzFMd38aARFk=
-gopkg.in/src-d/go-billy.v4 v4.3.0 h1:KtlZ4c1OWbIs4jCv5ZXrTqG8EQocr0g/d4DjNg70aek=
 gopkg.in/src-d/go-billy.v4 v4.3.0/go.mod h1:tm33zBoOwxjYHZIE+OV8bxTWFMJLrconzFMd38aARFk=
 gopkg.in/src-d/go-billy.v4 v4.3.1 h1:OkK1DmefDy1Z6Veu82wdNj/cLpYORhdX4qdaYCPwc7s=
 gopkg.in/src-d/go-billy.v4 v4.3.1/go.mod h1:tm33zBoOwxjYHZIE+OV8bxTWFMJLrconzFMd38aARFk=


### PR DESCRIPTION
- Fixed release download, instead of always fetching latest release now release will be fetched by tag name
- Optional compatiblity.json for portable NodeUI compatibility check
- Bump GO to 1.7
- Remove GenerateLocal as it was not useful